### PR TITLE
Change license from MIT to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ To run this app locally:
 
 ---
 
-## 📄 License  
+## 📄 License
 
-[MIT](./LICENSE)
+Licensed under the [Apache License, Version 2.0](./LICENSE).
+
 
 ---
 


### PR DESCRIPTION
Updated license section to reflect Apache License, Version 2.0.